### PR TITLE
Add an upper bound to the `dhall-json` versions providing `yaml-to-dhall`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dhall-json",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhall-json",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NPM package for `dhall-json`, based on https://github.com/justinwoo/npm-psc-package-bin-simple.",
   "os": [
     "darwin",

--- a/preinstall.js
+++ b/preinstall.js
@@ -60,14 +60,16 @@ const readVersion = name =>
 const dhallVersion = readVersion("dhall");
 const dhallJsonVersion = readVersion("dhall-json");
 
-const isLowerThan = (version, upperBound) =>
+const isLesserThan = (version, upperBound) =>
   semver.valid(version) && semver.lt(version, upperBound);
+const isGreaterThan = (version, lowerBound) =>
+  semver.valid(version) && semver.gt(version, lowerBound);
 
-if (isLowerThan(dhallJsonVersion, "1.2.8")) {
+if (isLesserThan(dhallJsonVersion, "1.2.8")) {
   throw new Error(`This release of the \`${pkg.name}\` npm package installs \`json-to-dhall\`, which isn’t provided by \`dhall-json@<1.2.8\`.`);
 }
-if (isLowerThan(dhallJsonVersion, "1.3.0")) {
-  throw new Error(`This release of the \`${pkg.name}\` npm package installs \`yaml-to-dhall\`, which isn’t provided by \`dhall-json@<1.3.0\`.`);
+if (isLesserThan(dhallJsonVersion, "1.3.0") || isGreaterThan(dhallJsonVersion, "1.5.0")) {
+  throw new Error(`This release of the \`${pkg.name}\` npm package installs \`yaml-to-dhall\`, which isn’t provided by \`dhall-json@<1.3.0 >1.5.0\`.`);
 }
 
 const release = `https://github.com/dhall-lang/dhall-haskell/releases/download/${dhallVersion}/dhall-json-${dhallJsonVersion}`;
@@ -87,7 +89,7 @@ if (process.platform === "win32") {
 } else {
   const isDarwin = process.platform === 'darwin';
 
-  if (isDarwin && isLowerThan(dhallJsonVersion, "1.4.0")) {
+  if (isDarwin && isLesserThan(dhallJsonVersion, "1.4.0")) {
     throw new Error(`Static macOS binaries aren’t provided by \`dhall-json@<1.4.0\`.`);
   }
 


### PR DESCRIPTION
This throws the following explicit error:

```
/Users/cyril/Workspace/app/frontend/node_modules/dhall-json/preinstall.js:72
  throw new Error(`This release of the \`${pkg.name}\` npm package installs \`yaml-to-dhall\`, which isn’t provided by \`dhall-json@<1.3.0 >1.5.0\`.`);
  ^

Error: This release of the `dhall-json` npm package installs `yaml-to-dhall`, which isn’t provided by `dhall-json@<1.3.0 >1.5.0`.
    at Object.<anonymous> (/Users/cyril/Workspace/app/frontend/node_modules/dhall-json/preinstall.js:72:9)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
```

instead of showing:

```
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path /Users/cyril/Workspace/app/frontend/node_modules/dhall-json/bin/yaml-to-dhall.exe
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/cyril/Workspace/app/frontend/node_modules/dhall-json/bin/yaml-to-dhall.exe'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cyril/.npm/_logs/2020-05-12T09_23_20_597Z-debug.log
```