### PR TITLE
Remove `yaml-to-dhall` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dhall-json",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "bin": {
     "dhall-to-json": "bin/dhall-to-json.exe",
     "dhall-to-yaml": "bin/dhall-to-yaml.exe",
-    "json-to-dhall": "bin/json-to-dhall.exe",
-    "yaml-to-dhall": "bin/yaml-to-dhall.exe"
+    "json-to-dhall": "bin/json-to-dhall.exe"
   },
   "scripts": {
     "preinstall": "node ./preinstall.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhall-json",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "NPM package for `dhall-json`, based on https://github.com/justinwoo/npm-psc-package-bin-simple.",
   "os": [
     "darwin",

--- a/preinstall.js
+++ b/preinstall.js
@@ -62,14 +62,9 @@ const dhallJsonVersion = readVersion("dhall-json");
 
 const isLesserThan = (version, upperBound) =>
   semver.valid(version) && semver.lt(version, upperBound);
-const isGreaterThan = (version, lowerBound) =>
-  semver.valid(version) && semver.gt(version, lowerBound);
 
 if (isLesserThan(dhallJsonVersion, "1.2.8")) {
   throw new Error(`This release of the \`${pkg.name}\` npm package installs \`json-to-dhall\`, which isn’t provided by \`dhall-json@<1.2.8\`.`);
-}
-if (isLesserThan(dhallJsonVersion, "1.3.0") || isGreaterThan(dhallJsonVersion, "1.5.0")) {
-  throw new Error(`This release of the \`${pkg.name}\` npm package installs \`yaml-to-dhall\`, which isn’t provided by \`dhall-json@<1.3.0 >1.5.0\`.`);
 }
 
 const release = `https://github.com/dhall-lang/dhall-haskell/releases/download/${dhallVersion}/dhall-json-${dhallJsonVersion}`;


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/fretlink/node-dhall-json-bin/pull/3.

The executable isn’t installed anymore with `dhall-json@>1.5.0`.